### PR TITLE
Try casting epoch timestamp to float first

### DIFF
--- a/gainsight-px-data-loader
+++ b/gainsight-px-data-loader
@@ -509,7 +509,7 @@ def mapRecord(csvRow, fieldMapping, dataType, datatypeMapping, importDatetimezon
                     except:
                         # Try converting it to an integer for epoch milliseconds
                         try:
-                            fieldValue = int(fieldValue)
+                            fieldValue = int(float(fieldValue))
                         except:
                             # Anything other than int is skipped
                             continue


### PR DESCRIPTION
This resolves cases where the timestamp was pulled as a stringified float e.g. `'1532549516000.0'` (which pandas loves to do). Currently, the script silently moves forward for these cases.